### PR TITLE
Bump `x/mod` dependency to support new `go.mod` format

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/dennwc/flatpak-go-mod
 
-go 1.19
+go 1.21.8
 
-require golang.org/x/mod v0.7.0
+require golang.org/x/mod v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-golang.org/x/mod v0.7.0 h1:LapD9S96VoQRhi/GrNTqeBJFrUjs5UHCAtTlgwA5oZA=
-golang.org/x/mod v0.7.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
+golang.org/x/mod v0.16.0 h1:QX4fJ0Rr5cPQCF7O9lh9Se4pmwfwskqZfq5moyldzic=
+golang.org/x/mod v0.16.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=


### PR DESCRIPTION
This updates the `x/mod` dependency to support the new Go mod format. Already tested as part of https://github.com/pojntfx/multiplex.